### PR TITLE
Add a runbook for refreshing the mapping from a new DCS export

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,11 @@ done for the A-4E-C post.
 The A-4E-C post's diagrams and HOTAS tables are generated from JSON under
 `tools/a4e/data/`, with the keybind layers driven by a DCS input export. Four
 marker-fenced regions of the post are rewritten by `tools/a4e/build.py`;
-everything outside them is hand-written. See `tools/a4e/README.md`.
+everything outside them is hand-written.
+
+To refresh it after re-mapping the stick in DCS, see
+[`tools/a4e/UPDATING.md`](tools/a4e/UPDATING.md); for how the generator works,
+[`tools/a4e/README.md`](tools/a4e/README.md).
 
 ## Licence
 

--- a/tools/a4e/README.md
+++ b/tools/a4e/README.md
@@ -1,11 +1,14 @@
 # Regenerating the A-4E-C post
 
-The HOTAS drawing and its four tables are generated from data. Re-map your stick
-in DCS, export the profile, run one command, and the template picture and the
-tables both follow.
+The HOTAS drawing and its tables are generated from data. Re-map your stick in
+DCS, replace `assets/config/a4ec.cfg.diff.lua`, run one command, and the template
+picture and the tables both follow.
+
+**For the step-by-step, see [UPDATING.md](UPDATING.md).** This file covers how the
+generator is put together.
 
 ```bash
-python3 tools/a4e/build.py ~/path/Gladiator.diff.lua modifiers.lua default.lua
+python3 tools/a4e/build.py assets/config/a4ec.cfg.diff.lua
 ```
 
 Arguments go in any order — each `.lua` is classified by reading it. Then preview:
@@ -18,14 +21,15 @@ bundle exec jekyll serve     # needs Ruby 3+; the macOS system Ruby (2.6) is too
 
 Every drawing in the post is inline SVG, so "rendering" is text generation — no
 rasteriser, no image pipeline, no binary assets to regenerate. The one real image
-is the VKB template photograph, which is `<use>`d four times and never redrawn.
+is the VKB template photograph, which is `<use>`d once per layer and never
+redrawn.
 
 ## What comes from where
 
 | File | What it holds |
 |---|---|
 | `data/controls.json` | one entry per physical VKB control: its DCS input name, its label field on the template, its text baseline |
-| `data/layers.json` | the four modifier layers and their titles |
+| `data/layers.json` | the modifier layers and their titles; the sheet count, `viewBox` and aria-label all derive from it |
 | `data/abbrev.json` | DCS command name → the short form that fits a label field |
 | `data/bindings.json` | the effective bindings, rewritten by `build.py` from your `.lua` |
 | `data/cockpit.json` | page 1, the plan-view cockpit map |
@@ -40,16 +44,9 @@ family is a line of JSON instead of hand-edited SVG coordinates.
 
 ## Which .lua to export
 
-* `Saved Games/DCS/Config/Input/A-4E-C/joystick/<device>.diff.lua` — your
-  bindings. **Holds only the changes from default**, so pass it together with:
-* `Mods/aircraft/A-4E-C/Input/A-4E-C/joystick/default.lua` — the mod's own
-  catalogue. Without it, a control still sitting on the DCS default is
-  indistinguishable from an unbound one and renders as unbound.
-* `Saved Games/DCS/Config/Input/modifiers.lua` — what makes `JOY_BTN28` display
-  as `F2`. Without it, layers whose modifier is not literally named `F2`/`F3`
-  come out empty.
-
-No Lua runtime is needed; `lua.py` reads the table format directly.
+See [UPDATING.md](UPDATING.md) — it covers the file shapes, which extra files
+help, and what each report line means. No Lua runtime is needed; `lua.py` reads
+the table format directly.
 
 ## When something looks wrong
 
@@ -59,8 +56,8 @@ No Lua runtime is needed; `lua.py` reads the table format directly.
 * bindings on inputs no control claims — a keyboard bind, a second device, or a
   button missing from the roster. These are **not drawn**, and saying so is the
   point: nothing is silently dropped;
-* labels too long for a 347-unit field, as a copy-pasteable `abbrev.json` line;
-* which of the four regions actually changed.
+* labels too long for a field (16 characters), as copy-pasteable `abbrev.json` lines;
+* which of the four fenced regions actually changed.
 
 If a label lands in the wrong place, fix that control's `anchor`/`box` in
 `controls.json`. If a whole control is misidentified, its `input` is wrong — that
@@ -94,7 +91,7 @@ whitespace and the order of non-overlapping siblings may differ.
 
 `harvest.py` and `gen_roster.py` rebuilt the data files from the hand-authored
 SVGs and are kept for provenance. You only need them if the post is re-authored
-by hand. `harvest.py` recovers the four POV label boxes that no layer shades by
+by hand. `harvest.py` recovers POV label boxes that no layer shades by
 detecting the printed fields on the template JPG (needs Pillow + numpy).
 
 ## Files
@@ -102,7 +99,7 @@ detecting the printed fields on the template JPG (needs Pillow + numpy).
 ```
 lua.py           Lua table reader, no runtime required
 dcs.py           .lua -> normalised bindings; merges default + diff
-render_vkb.py    page 3: the template SVG and the four tables
+render_vkb.py    page 3: the template SVG and the per-layer tables
 render_pages.py  page 1 and page 2
 inject.py        marker-fenced in-place replacement
 build.py         the entry point

--- a/tools/a4e/UPDATING.md
+++ b/tools/a4e/UPDATING.md
@@ -1,0 +1,134 @@
+# Updating the HOTAS mapping after a re-map
+
+The keybind drawing and its tables are generated from
+`assets/config/a4ec.cfg.diff.lua`, the DCS export that lives in this repo.
+Re-map in DCS, replace that one file, run one command.
+
+```bash
+# 1. export from DCS, then overwrite the config in the repo
+cp "/path/to/Saved Games/DCS/Config/Input/A-4E-C/joystick/<device>.diff.lua" \
+   assets/config/a4ec.cfg.diff.lua
+
+# 2. see what would change, without writing anything
+python3 tools/a4e/build.py --dry-run assets/config/a4ec.cfg.diff.lua
+
+# 3. do it
+python3 tools/a4e/build.py assets/config/a4ec.cfg.diff.lua
+
+# 4. check and commit
+python3 tools/a4e/selftest.py
+git add -A && git commit && git push
+```
+
+Step 2 is worth doing every time. It prints the whole reconciliation before
+touching the post, and everything you need to react to is in that output.
+
+## Where DCS keeps the file
+
+Exact paths vary by install — `DCS.openbeta` versus `DCS`, a relocated Saved
+Games folder, the mod in the game directory versus Saved Games. Search for the
+filename rather than trusting a path. In DCS, **Controls → Save profile as…**
+also writes the same shape.
+
+Optionally pass two more files, in any order — each is classified by reading it:
+
+| File | Why you might add it |
+|---|---|
+| `.../Mods/aircraft/A-4E-C/Input/A-4E-C/joystick/default.lua` | A diff holds **only your changes**. Without the default, a control still sitting on the DCS default renders as unbound. |
+| `Saved Games/DCS/Config/Input/modifiers.lua` | Only needed if your export stores modifiers as raw buttons (`JOY_BTN28`) rather than names (`F2`). The current config stores names, so this is not needed — and `build.py` only asks for it when it sees raw names. |
+
+## Reading the report
+
+Four things get printed. Each has a specific response.
+
+**Added and removed bindings.** Sanity-check the list against what you actually
+changed in DCS. A long `-` list with a short `+` list usually means a file is
+missing rather than that you unbound thirty things.
+
+**`bindings on inputs the roster does not describe`.** A binding on a button the
+drawing has no slot for — a keyboard bind, a second device, or a control missing
+from the roster. These are listed but **not drawn**. To place one, add an entry
+to `data/controls.json` with its `input`, plus a `box` and `anchor` for its
+printed field on the template. To leave it in the tables only, add the entry with
+`"box": null, "anchor": null`.
+
+**`label(s) too long ... and clipped`.** Real DCS command names run long
+(`Trim Switch - NOSE DOWN`). A field holds **16 characters**. The report emits
+copy-pasteable lines; paste them into `data/abbrev.json` under `map` and edit the
+short form to something you would actually want printed:
+
+```json
+"AN/ARN-52 TACAN Mode Switch - CCW": "TACAN MODE CCW",
+```
+
+Without an entry the label still renders, just truncated with an ellipsis.
+
+**`per layer`.** Counts per modifier combination. A layer showing `0` when you
+expect binds means its modifier name in `data/layers.json` does not match the
+name in the export's `reformers`.
+
+## A new modifier
+
+If you add one in DCS, add a layer to `data/layers.json`. `modifiers` must match
+the names the export uses, spelled identically:
+
+```json
+{ "modifiers": ["Pinky"], "n": 5, "title": "zoom",
+  "svgTitle": "ZOOM", "chip": "Hold Pinky", "svgChip": "HOLD PINKY" }
+```
+
+The template sheet, its heading and its table all follow. Sheet height, the SVG
+`viewBox` and the aria-label are all derived from the layer count.
+
+## When a label lands in the wrong place
+
+That control's `anchor` (text baseline) or `box` (the shaded field) is wrong in
+`data/controls.json`. Most likely on a control that had no binding before, since
+those coordinates had never been exercised. `data/template_fields.json` lists
+every printed field detected on the template JPG, in the same units, which is the
+quickest way to find the right numbers.
+
+## Checks
+
+```bash
+python3 tools/a4e/selftest.py            # do the data files still describe the post?
+python3 tools/a4e/build.py --check       # exit 1 if the post is stale
+python3 tools/a4e/build.py --dry-run …   # render and report, write nothing
+```
+
+Re-running `build.py` is idempotent: a second run reports `nothing (already
+current)`.
+
+## Previewing
+
+```bash
+bundle exec jekyll serve      # http://localhost:4000
+```
+
+Needs Ruby 3+. The macOS system Ruby (2.6) is too old, so this needs
+`brew install ruby` or rbenv first.
+
+Without Jekyll you can still check the generated markup by opening the post body
+in a browser — strip the front matter, wrap it in a minimal HTML page, and serve
+the repo root so `/assets/img/...` resolves. What that catches, and Jekyll does
+not, is label overflow: no label may be wider than 271 units, measured with
+`getBBox()`.
+
+## Commit the data too
+
+`build.py` rewrites `data/bindings.json` from your export. Commit it — a bare
+`python3 tools/a4e/build.py` with no arguments redraws from it, so it is the
+record of the published mapping, not a scratch file.
+
+## Gotchas seen in real exports
+
+- **`changed`** — DCS writes this instead of `added` when a combo's filter
+  (curve, deadzone, invert) is edited but the binding stays. It counts as a live
+  binding; a parser that only reads `added` silently drops it.
+- **`removed` without the default** — removals reference bindings that only exist
+  in `default.lua`. Harmless, but they cannot be applied unless you pass it.
+- **Modifier spelling** — `reformers` may hold names (`F2`) or raw buttons
+  (`JOY_BTN28`). Names need no `modifiers.lua`; raw buttons do.
+
+See `README.md` in this directory for how the generator is put together and what
+each file does.


### PR DESCRIPTION
`tools/a4e/README.md` explains how the generator is built, which is the wrong
document to open when you have just re-mapped the stick and want the page to
follow. So the task is split out:

| | |
|---|---|
| **`tools/a4e/UPDATING.md`** | what to do after a re-map |
| `tools/a4e/README.md` | how the generator works |

The runbook is written around the config living in the repo, which is the actual
workflow — overwrite `assets/config/a4ec.cfg.diff.lua`, run `build.py`, commit —
rather than the loose-file-somewhere flow the old README assumed.

It covers what each line of the report means and what to do about it: an unplaced
input, a clipped label, a layer showing zero, a label in the wrong position, and
adding a modifier. It also records the three things real exports turned out to do
that a first-pass parser gets wrong:

- `changed` instead of `added` when only a filter was edited
- `removed` entries that cannot be applied without `default.lua`
- `reformers` holding modifier *names* rather than raw buttons

Stale facts in `tools/a4e/README.md` reconciled while there: four layers is now
five and derived from `layers.json`, the label budget is 16 characters, and the
export-paths section defers to the runbook instead of repeating it. The repo
README links both.

Every command in both documents was run against this tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
